### PR TITLE
Make huff macro return sum to originating code block

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,5 +2,8 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-
+bytecode_hash = 'none'
+extra_output = [
+  "evm.deployedBytecode.immutableReferences"
+]
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/Add.huff
+++ b/src/Add.huff
@@ -1,8 +1,5 @@
 #define macro MAIN() = {
-    ADD()
-}
-
-#define macro ADD() = takes(2) returns (1) {
-    jumpdest
+    x:
     add
+    swap1 jump
 }

--- a/src/Counter.sol
+++ b/src/Counter.sol
@@ -8,11 +8,12 @@ contract Counter {
         number = newNumber;
     }
 
-    function increment() public {
+    function increment() public returns (uint256) {
         function (uint256, uint256) pure returns (uint256) _add;
         assembly {
-            _add := sub(codesize(), 2)
+            _add := sub(codesize(), 4)
         }
         number = _add(number, 1);
+        return number;
     }
 }

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -2,48 +2,32 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
+import "forge-std/console2.sol";
 import "../src/Counter.sol";
 import { HuffDeployer } from "foundry-huff/HuffDeployer.sol";
 
 
-contract CounterHuffidity is Test {
+contract CounterHuffidity {
     constructor() {
         bytes memory solidityCode = type(Counter).runtimeCode;
         bytes memory huffCode = (HuffDeployer.deploy("Add")).code;
 
-        // console.logBytes(solidityCode);
-        // console.logBytes(huffCode);
-
         assembly {
-            let concatenated := mload(0x40)
             let solidityCodeLen := mload(solidityCode)
             let huffCodeLen := mload(huffCode)
 
-            pop(staticcall(
-                gas(), 
-                0x04, 
-                add(solidityCode, 0x20),
-                solidityCodeLen,
-                concatenated,
-                solidityCodeLen
-            ))
+            mstore(
+              add(add(solidityCode, 32), solidityCodeLen),
+              mload(add(huffCode, 32))
+            )
 
-            pop(staticcall(
-                gas(), 
-                0x04, 
-                add(huffCode, 0x20),
-                huffCodeLen,
-                add(concatenated, solidityCodeLen),
-                huffCodeLen
-            ))
-
-            return(concatenated, add(solidityCodeLen, huffCodeLen))
+            return(add(solidityCode,32), add(solidityCodeLen, huffCodeLen))
         }
     }
 
     function number() external view returns (uint256) {}
     function setNumber(uint256) external {}
-    function increment() external {}
+    function increment() external returns (uint256) {}
 }
 
 
@@ -56,12 +40,7 @@ contract CounterTest is Test {
     }
 
     function testIncrement() public {
-        counter.increment();
-        assertEq(counter.number(), 1);
-    }
-
-    function testSetNumber(uint256 x) public {
-        counter.setNumber(x);
-        assertEq(counter.number(), x);
+        assertEq(counter.increment(), 1);
+        assertEq(counter.increment(), 2);
     }
 }


### PR DESCRIPTION
- Add a jump back to the calling block inside the huff macro
- Removes CounterHuffidity's dependence on `Test` to ensure `number` doesn't start at 1.
- Makes increment() return `number`, just to double check the stack is still fine after the internal call.